### PR TITLE
Handle missing Codex rate limits via app-server fallback

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,34 +1,5 @@
-# Source files (compiled output is in /out)
+package-vsix.cjs
+.gitignore
+node_modules/**
 src/**
 tsconfig.json
-.gitignore
-
-# Development files
-.vscode/**
-npm-debug.log*
-*.vsix
-
-# Dependency sources (extension bundle is self-contained)
-node_modules/**
-
-# Build artifacts
-*.map
-
-# OS files
-.DS_Store
-Thumbs.db
-
-# IDE files
-*.swp
-*.swo
-
-# Logs
-logs
-*.log
-
-# Testing
-test/**
-coverage/**
-
-# Git
-.git/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,58 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Nothing yet.
+
+## [0.13.0] - 2026-03-08
+
+- Add a fallback to the official local `codex app-server`
+  `account/rateLimits/read` API when newer `token_count` events omit
+  `rate_limits`.
+- Reuse the newest session snapshot that still contains `rate_limits` if the
+  local app-server fallback is unavailable.
+- Show the active rate-limit source in the tooltip and detail view to make
+  fallback behavior easy to verify during testing.
+- Add an optional status-bar source indicator with `Live`, `API`, and `LS`
+  labels for quick verification.
+- Prefix output-channel entries with explicit log levels such as `INFO`,
+  `WARN`, and `ERROR`, and add a configurable minimum log level setting.
+- Log the direct live-session source explicitly, so source switches are visible
+  in the Output channel even when no fallback is needed.
+- Add an npm packaging helper that writes VSIX files as
+  `codex-ratelimit-<version>.vsix`.
+- Prefer bundled Codex executables before `codex` on `PATH` and avoid noisy
+  per-candidate failure logs when a later fallback candidate succeeds.
+- Support newer absolute reset timestamps such as `reset_at` alongside the
+  historical session formats.
+
 ## [0.12.0] - 2025-11-08
-- Add opt-in setting to show the Output panel when errors are logged so it no longer steals focus by default.
+
+- Add an opt-in setting to show the Output panel when errors are logged so it
+  no longer steals focus by default.
 
 ## [0.11.0] - 2025-11-08
-- Switch session discovery to a two-phase search that prioritizes files touched within the last hour before walking the previous seven days by modification time, ensuring continued work in older sessions is detected.
+
+- Switch session discovery to a two-phase search that prioritizes files touched
+  within the last hour before walking the previous seven days by modification
+  time, ensuring continued work in older sessions is detected.
 
 ## [0.10.0] - 2025-10-27
-- Add customizable color settings for status bar and webview progress indicators with warning/critical thresholds.
-- Improve tooltips and webview displays to handle outdated data and format token totals more readably.
-- Make the rate limit parser resilient to missing usage payloads while keeping the UI responsive.
-- Support new input data format with both absolute (`resets_at`) and relative (`resets_in_seconds`) timestamp formats.
-- Add validation for `window_minutes` to prevent calculation errors with invalid or missing window data.
-- Improve reset time calculation accuracy by using current time instead of record timestamp.
+
+- Add customizable color settings for status bar and webview progress
+  indicators with warning and critical thresholds.
+- Improve tooltips and webview displays to handle outdated data and format
+  token totals more readably.
+- Make the rate-limit parser resilient to missing usage payloads while keeping
+  the UI responsive.
+- Support new input data formats with both absolute (`resets_at`) and relative
+  (`resets_in_seconds`) timestamp fields.
+- Add validation for `window_minutes` to prevent calculation errors with
+  invalid or missing window data.
+- Improve reset-time calculation accuracy by using current time instead of the
+  record timestamp.
 
 ## [0.9.0] - 2025-09-28
+
 - First public release of the Codex Rate Limit Monitor extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Nothing yet.
+- Nothing to see here
 
 ## [0.13.0] - 2026-03-08
 
@@ -27,6 +27,9 @@ All notable changes to this project will be documented in this file.
   per-candidate failure logs when a later fallback candidate succeeds.
 - Support newer absolute reset timestamps such as `reset_at` alongside the
   historical session formats.
+- Detect current bundled Codex executable layouts on macOS and Windows more
+  reliably when the app-server fallback is needed, including `macos-*` and
+  `windows-aarch64` directory names used by recent OpenAI extension builds.
 
 ## [0.12.0] - 2025-11-08
 

--- a/README.md
+++ b/README.md
@@ -1,166 +1,197 @@
 # Codex Rate Limit Monitor
 
-A Visual Studio Code/Cursor/Windsurf extension for monitoring OPENAI Codex rate limits in real-time.
+A Visual Studio Code, Cursor, and Windsurf extension that shows OpenAI Codex
+rate-limit usage directly in the status bar and a detailed panel.
 
 ## Features
 
-- **Status Bar Display**: Shows 5-hour and weekly usage percentages directly in the VSCode status bar
-- **Color-coded Indicators**: Visual warnings when approaching rate limits
-- **Detailed View**: Click the status bar to see comprehensive rate limit information
-- **Automatic Updates**: Refreshes every 10 seconds to keep data current
-- **TUI-style Interface**: Familiar progress bars similar to the Python CLI tool
+- Shows 5-hour and weekly Codex usage percentages in the status bar.
+- Uses configurable warning and critical colors for the status bar and detail
+  view.
+- Opens a detailed panel with reset times, time progress, and token usage.
+- Refreshes automatically every 10 seconds by default and pauses while the
+  window is unfocused.
+- Handles current Codex data formats by combining session files with the local
+  `codex app-server` fallback when needed.
+- Can optionally show a short rate-limit source label directly in the status
+  bar.
+- Formats Output channel entries with explicit log levels such as `INFO`,
+  `WARN`, and `ERROR`.
+- Shows the active rate-limit source in the tooltip and detail view so you can
+  verify whether values came from live session data, the app-server fallback,
+  or a session snapshot fallback.
 
 ## Installation
 
-For most users, simply search for "Codex Rate Limit Monitor" in your editor's extension marketplace and install it directly.
+For most users, install the extension from the editor marketplace.
 
-### Package and Install the Extension
+### Build and install locally
 
-#### Step 1: Install VSCE (VSCode Extension Manager)
+Prerequisites:
+
+- Visual Studio Code 1.96.0 or newer
+- Node.js for local development
+
+Node.js 20 or newer is recommended when packaging with recent versions of
+`@vscode/vsce`.
+
+Build a VSIX locally:
+
 ```bash
-npm install -g @vscode/vsce
-```
-
-#### Step 2: Package the Extension
-```bash
-# Navigate to the extension directory
 cd codex-ratelimit-vscode
-
-# Install dependencies and compile
-npm install
-npm run compile
-
-# Package into .vsix file
-vsce package
+npm ci
+npm run package:vsix
 ```
 
-This creates a `codex-ratelimit-X.X.X.vsix` file.
+Install the generated VSIX:
 
-#### Step 3: Install the Packaged Extension
-
-**Option A: Using VSCode UI**
-1. Open VSCode
-2. Go to Extensions panel (`Ctrl+Shift+X` or `Cmd+Shift+X`)
-3. Click the `...` menu → "Install from VSIX..."
-4. Select the `.vsix` file you created
-
-**Option B: Using Command Line**
 ```bash
-code --install-extension codex-ratelimit-X.X.X.vsix
+code --install-extension codex-ratelimit-<version>.vsix
 ```
 
-**Option C: Using VSCode Command Palette**
-1. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on Mac)
-2. Type "Extensions: Install from VSIX..."
-3. Select the `.vsix` file
-
-#### Step 4: Reload VSCode
-After installation, reload VSCode window (`Ctrl+Shift+P` → "Developer: Reload Window") to activate the extension.
+After installation, reload the VS Code window.
 
 ## Usage
 
-### Status Bar
+### Status bar
 
-The extension displays rate limit information in the VSCode status bar:
+The extension displays rate-limit information in the status bar:
 
-```
+```text
 ⚡ 5H: 45% | Weekly: 23%
 ```
 
-- **5H**: 5-hour session usage percentage
-- **Weekly**: Weekly limit usage percentage
-- Colors change based on usage levels (green → yellow → red)
+If you enable the optional source indicator, it can look like this:
 
-### Detailed View
+```text
+⚡ API | 5H: 45% | Weekly: 23%
+```
 
-Click the status bar item or use the command `Codex Rate Limit: Show Details` to open a detailed view showing:
+- `5H` is the 5-hour session usage percentage.
+- `Weekly` is the weekly usage percentage.
+- Colors follow the configured warning and critical thresholds.
+- Optional source labels are `Live` for direct session data, `API` for the
+  `codex app-server` fallback, and `LS` for the latest session snapshot
+  fallback.
 
-- 5-hour session progress (time and usage)
-- Weekly limit progress (time and usage)
-- Reset times and outdated status indicators
-- Token usage summary
+### Detailed view
 
-## Companion CLI Utility
+Click the status bar item or run `Codex Rate Limit: Show Details` to open a
+detailed view with:
 
-Prefer a terminal workflow? The [codex-ratelimit](https://github.com/xiangz19/codex-ratelimit) project provides a single-file Python CLI/TUI tool that mirrors the progress bars and live rate-limit updates used here.
+- 5-hour session time and usage progress
+- Weekly time and usage progress
+- The active rate-limit source and source detail
+- Reset times and outdated indicators
+- Total and last token usage summaries
+
+### Output logs
+
+The `Codex Rate Limit` Output channel now prefixes entries with a level label:
+
+```text
+[2026-03-08T14:59:50.000Z] [INFO ] Using live session rate limits from: ...
+[2026-03-08T15:00:00.000Z] [INFO ] Using Codex app-server fallback rate limits from: ...
+[2026-03-08T15:00:10.000Z] [WARN ] No rate limit data found: ...
+[2026-03-08T15:00:20.000Z] [ERROR] Error during stats update: ...
+```
+
+You can control the minimum level with `codexRatelimit.logLevel`.
+
+## Companion CLI utility
+
+Prefer a terminal workflow? The
+[codex-ratelimit](https://github.com/xiangz19/codex-ratelimit) project provides
+a single-file Python CLI and TUI with a similar live view of Codex rate limits.
 
 ## Commands
 
-- `codex-ratelimit.refreshStats` - Manually refresh rate limit data
-- `codex-ratelimit.showDetails` - Open detailed rate limit view
-- `codex-ratelimit.openSettings` - Open extension settings page
+- `codex-ratelimit.refreshStats` refreshes the displayed rate-limit data.
+- `codex-ratelimit.showDetails` opens the detailed rate-limit panel.
+- `codex-ratelimit.openSettings` opens the extension settings.
 
 ## Configuration
 
-The extension can be configured through VSCode settings:
+The extension exposes these settings:
 
-- `codexRatelimit.enableLogging` - Enable detailed logging for debugging
-- `codexRatelimit.enableStatusBarColors` - Enable color-coded status bar
-- `codexRatelimit.warningThreshold` - Usage percentage for warning colors (default: 70%)
-- `codexRatelimit.refreshInterval` - How often to refresh stats in seconds (5-3600, default: 10)
-- `codexRatelimit.sessionPath` - Custom path to Codex sessions directory
+- `codexRatelimit.enableLogging` is a legacy compatibility toggle for older
+  setups that have not switched to `codexRatelimit.logLevel` yet.
+- `codexRatelimit.logLevel` sets the minimum output level: `off`, `error`,
+  `warn`, `info`, or `debug`.
+- `codexRatelimit.showOutputOnError` opens the Output panel automatically when
+  an error is logged.
+- `codexRatelimit.color.enable` enables colorized status bar text and progress
+  bars.
+- `codexRatelimit.color.warningColor` sets the warning color.
+- `codexRatelimit.color.warningThreshold` sets the warning threshold in percent.
+- `codexRatelimit.color.criticalColor` sets the critical color.
+- `codexRatelimit.color.criticalThreshold` sets the critical threshold in
+  percent.
+- `codexRatelimit.refreshInterval` controls the refresh interval in seconds.
+- `codexRatelimit.sessionPath` overrides the default Codex sessions path.
+- `codexRatelimit.statusBar.sourceIndicator` controls whether the status bar
+  shows no source label, a short label, or a full label.
 
-## How It Works
+## How it works
 
-The extension monitors Codex session files located at `~/.codex/sessions/` by default. It:
+The extension reads Codex data locally in this order:
 
-1. Searches for the latest `token_count` events in session files using a two-phase, modification-time-based scan (fast path checks today's files from the last hour, fallback walks all session files from the previous seven days by most recent edit)
-2. Extracts rate limit information (5-hour and weekly limits)
-3. Calculates usage percentages and time progress
-4. Updates the status bar every 10 seconds
-5. Handles outdated data and error states gracefully
+1. It scans recent `~/.codex/sessions/.../rollout-*.jsonl` files and finds the
+   latest `token_count` event for token usage.
+2. If that latest `token_count` event still contains `rate_limits`, it uses
+   them directly.
+3. If the current local setup uses the default Codex sessions path and the
+   latest `token_count` omits `rate_limits`, it queries the local
+   `codex app-server` with `account/rateLimits/read`.
+4. If the app-server request fails or returns no usable snapshot, it reuses the
+   newest session record that still contains `rate_limits`.
+5. It calculates reset times, time progress, and usage progress for the UI.
+
+The tooltip and detail view show the active rate-limit source, and the status
+bar can optionally show a short source label. That makes it easy to confirm
+whether the extension is using the app-server fallback or only an older
+session snapshot.
+
+If you configure a custom `codexRatelimit.sessionPath`, the extension stays
+session-file based and skips the local app-server fallback.
 
 ## Development
 
-### Requirements
-
-- Visual Studio Code 1.96.0 or higher
-- Node.js for development
-
-### Setup for Development and Testing
-
-1. **Open the extension directory in VSCode**
-2. **Install dependencies:**
-   ```bash
-   npm install
-   ```
-3. **Compile TypeScript:**
-   ```bash
-   npm run compile
-   ```
-4. **Press `F5`** to launch a new Extension Development Host window
-5. The extension will activate automatically
-
-### Development Workflow
+### Setup
 
 ```bash
-# Watch for changes (auto-recompile on file changes)
-npm run watch
-
-# Manual compilation when needed
+npm ci
 npm run compile
+npm run package:vsix
+```
 
-# Run the extension for testing
-# Press F5 in VSCode to launch Extension Development Host
+Press `F5` in VS Code to launch an Extension Development Host window.
+
+### Workflow
+
+```bash
+npm run watch
+npm run compile
 ```
 
 ## Architecture
 
-```
+```text
 src/
 ├── extension.ts           # Main extension entry point
 ├── services/
-│   ├── ratelimitParser.ts # Core logic for parsing session files
+│   ├── codexAppServer.ts  # Local Codex app-server fallback for live rate limits
+│   ├── ratelimitParser.ts # Session discovery and rate-limit aggregation
 │   └── logger.ts          # Logging utilities
 ├── handlers/
 │   ├── statusBar.ts       # Status bar management
-│   └── webView.ts         # Detailed view WebView
+│   └── webView.ts         # Detailed view webview
 ├── utils/
-│   └── updateStats.ts     # Stats update and refresh logic
+│   └── updateStats.ts     # Refresh scheduling and update flow
 └── interfaces/
-    └── types.ts           # TypeScript type definitions
+    └── types.ts           # Shared TypeScript types
 ```
 
 ## License
 
-MIT License
+MIT

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ The extension reads Codex data locally in this order:
    newest session record that still contains `rate_limits`.
 5. It calculates reset times, time progress, and usage progress for the UI.
 
+When the app-server fallback uses the bundled Codex executable from the OpenAI
+extension, the lookup supports the current platform directory layout such as
+`macos-aarch64`, `macos-x86_64`, `linux-aarch64`, `linux-x86_64`,
+`windows-aarch64`, and `windows-x86_64` before falling back to `codex` on
+`PATH`.
+
 The tooltip and detail view show the active rate-limit source, and the status
 bar can optionally show a short source label. That makes it easy to confirm
 whether the extension is using the app-server fallback or only an older

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-ratelimit",
-  "version": "0.10.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-ratelimit",
-      "version": "0.10.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.3.10"

--- a/package-vsix.cjs
+++ b/package-vsix.cjs
@@ -1,0 +1,37 @@
+const { spawnSync } = require('child_process');
+const { readFileSync } = require('fs');
+const path = require('path');
+
+const repoRoot = __dirname;
+const packageJsonPath = path.join(repoRoot, 'package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const version = packageJson.version;
+
+if (typeof version !== 'string' || version.trim() === '') {
+  console.error('Unable to determine extension version from package.json');
+  process.exit(1);
+}
+
+const outputFile = `codex-ratelimit-${version}.vsix`;
+const npmCliPath = process.env.npm_execpath;
+
+if (typeof npmCliPath !== 'string' || npmCliPath.trim() === '') {
+  console.error('Unable to determine npm executable path from npm_execpath');
+  process.exit(1);
+}
+
+const result = spawnSync(
+  process.execPath,
+  [npmCliPath, 'exec', '--yes', '@vscode/vsce', 'package', '--', '--out', outputFile],
+  {
+    cwd: repoRoot,
+    stdio: 'inherit'
+  }
+);
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Codex Rate Limit Monitor",
   "description": "A VSCode extension for monitoring Codex rate limits",
   "license": "MIT",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "publisher": "xiangz19",
   "icon": "icon.png",
   "repository": {
@@ -54,7 +54,28 @@
           "codexRatelimit.enableLogging": {
             "type": "boolean",
             "default": false,
-            "description": "Enable detailed logging for debugging purposes.",
+            "description": "Legacy logging toggle. If enabled and no explicit log level is selected, the effective minimum log level becomes Info.",
+            "deprecationMessage": "Use codexRatelimit.logLevel instead.",
+            "scope": "window"
+          },
+          "codexRatelimit.logLevel": {
+            "type": "string",
+            "default": "warn",
+            "enum": [
+              "off",
+              "error",
+              "warn",
+              "info",
+              "debug"
+            ],
+            "enumDescriptions": [
+              "Disable extension logging.",
+              "Show only error messages.",
+              "Show warnings and errors.",
+              "Show informational messages, warnings, and errors.",
+              "Show all logs, including verbose debug messages."
+            ],
+            "description": "Minimum log level written to the Codex Rate Limit output channel.",
             "scope": "window"
           },
           "codexRatelimit.showOutputOnError": {
@@ -110,6 +131,22 @@
             "maximum": 3600,
             "description": "How often to refresh the stats (in seconds). Minimum 5 seconds, maximum 1 hour.",
             "scope": "window"
+          },
+          "codexRatelimit.statusBar.sourceIndicator": {
+            "type": "string",
+            "default": "off",
+            "enum": [
+              "off",
+              "compact",
+              "full"
+            ],
+            "enumDescriptions": [
+              "Hide the rate-limit source in the status bar.",
+              "Show a short source label such as Live, API, or LS.",
+              "Show a full source label such as Live Session, App Server, or Last Session."
+            ],
+            "description": "Optionally show the active rate-limit source in the status bar.",
+            "scope": "window"
           }
         }
       }
@@ -119,6 +156,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "npm run typecheck && npm run bundle",
     "bundle": "esbuild src/extension.ts --bundle --platform=node --format=cjs --external:vscode --sourcemap --outfile=out/extension.js --log-level=info",
+    "package:vsix": "node package-vsix.cjs",
     "typecheck": "tsc -p ./ --noEmit",
     "watch": "esbuild src/extension.ts --bundle --platform=node --format=cjs --external:vscode --sourcemap --outfile=out/extension.js --watch",
     "pretest": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,11 +9,9 @@ let extensionContext: vscode.ExtensionContext;
 
 export function activate(context: vscode.ExtensionContext) {
   try {
-    log('Extension activation started');
-    extensionContext = context;
-
-    // Initialize logging
     initializeLogging();
+    log('Extension activation started', 'info');
+    extensionContext = context;
 
     // Create status bar item
     statusBarItem = createStatusBarItem();
@@ -21,17 +19,17 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Register commands
     const refreshCommand = vscode.commands.registerCommand('codex-ratelimit.refreshStats', async () => {
-      log('Manual refresh triggered', true); // Force log as error to ensure it shows
+      log('Manual refresh triggered', 'info');
       await updateStats();
     });
 
     const showDetailsCommand = vscode.commands.registerCommand('codex-ratelimit.showDetails', () => {
-      log('Show details command triggered');
+      log('Show details command triggered', 'debug');
       RateLimitWebView.createOrShow(context.extensionUri);
     });
 
     const openSettingsCommand = vscode.commands.registerCommand('codex-ratelimit.openSettings', async () => {
-      log('Open settings command triggered');
+      log('Open settings command triggered', 'debug');
       await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:xiangz19.codex-ratelimit');
     });
 
@@ -43,7 +41,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Add configuration change listener
     const configListener = vscode.workspace.onDidChangeConfiguration(async (e) => {
       if (e.affectsConfiguration('codexRatelimit')) {
-        log('Configuration changed, restarting timer with new interval...');
+        log('Configuration changed, restarting timer with new interval...', 'info');
         if (e.affectsConfiguration('codexRatelimit.refreshInterval')) {
           // Restart timer with new interval
           startRefreshTimer();
@@ -66,11 +64,11 @@ export function activate(context: vscode.ExtensionContext) {
     // Start the refresh timer and do initial update
     startRefreshTimer();
 
-    log('Extension activation completed successfully');
+    log('Extension activation completed successfully', 'info');
 
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
-    log(`Failed to activate extension: ${errorMessage}`, true);
+    log(`Failed to activate extension: ${errorMessage}`, 'error');
     vscode.window.showErrorMessage(`Codex Rate Limit extension failed to activate: ${errorMessage}`);
     throw error;
   }
@@ -78,7 +76,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 export function deactivate() {
   try {
-    log('Extension deactivation started');
+    log('Extension deactivation started', 'info');
 
     // Clean up timers
     cleanup();
@@ -86,10 +84,10 @@ export function deactivate() {
     // Dispose logger
     disposeLogger();
 
-    log('Extension deactivation completed successfully');
+    log('Extension deactivation completed successfully', 'info');
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
-    log(`Failed to deactivate extension cleanly: ${errorMessage}`, true);
+    log(`Failed to deactivate extension cleanly: ${errorMessage}`, 'error');
     throw error;
   }
 }

--- a/src/handlers/statusBar.ts
+++ b/src/handlers/statusBar.ts
@@ -1,11 +1,12 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { RateLimitData } from '../interfaces/types';
 import { log } from '../services/logger';
 
 let statusBarItem: vscode.StatusBarItem;
 
 export function createStatusBarItem(): vscode.StatusBarItem {
-  log('Creating status bar item...');
+  log('Creating status bar item...', 'debug');
   statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
   statusBarItem.command = 'codex-ratelimit.showDetails';
   return statusBarItem;
@@ -38,6 +39,44 @@ export function formatRelativeTime(date: Date): string {
   const minutes = date.getMinutes().toString().padStart(2, '0');
   const seconds = date.getSeconds().toString().padStart(2, '0');
   return `${hours}:${minutes}:${seconds}`;
+}
+
+function getRateLimitSourceSummary(data: RateLimitData): { label: string; detail?: string } {
+  if (!data.rate_limit_source) {
+    return { label: 'Unavailable' };
+  }
+
+  const detail = data.rate_limit_source.detail
+    ? path.basename(data.rate_limit_source.detail)
+    : undefined;
+
+  return {
+    label: data.rate_limit_source.label,
+    detail
+  };
+}
+
+function getStatusBarSourceIndicator(data: RateLimitData): string {
+  const config = vscode.workspace.getConfiguration('codexRatelimit');
+  const mode = config.get<'off' | 'compact' | 'full'>(
+    'statusBar.sourceIndicator',
+    'off'
+  );
+
+  if (mode === 'off' || !data.rate_limit_source) {
+    return '';
+  }
+
+  switch (data.rate_limit_source.kind) {
+    case 'token_count':
+      return mode === 'compact' ? 'Live' : 'Live Session';
+    case 'app_server':
+      return mode === 'compact' ? 'API' : 'App Server';
+    case 'session_snapshot':
+      return mode === 'compact' ? 'LS' : 'Last Session';
+    default:
+      return '';
+  }
 }
 
 function createProgressBar(percentage: number, type: 'usage' | 'time', outdated: boolean): string {
@@ -150,12 +189,17 @@ export function createMarkdownTooltip(data: RateLimitData): vscode.MarkdownStrin
 
   const total = data.total_usage;
   const last = data.last_usage;
+  const source = getRateLimitSourceSummary(data);
 
   function formatTokenNumber(num: number): string {
     const numInK = Math.round(num / 1000);
     return numInK.toLocaleString('en-US') + ' K';
   }
 
+  tooltip.appendMarkdown(`**Rate-Limit Source:** ${source.label}\n\n`);
+  if (source.detail) {
+    tooltip.appendMarkdown(`**Source Detail:** \`${source.detail}\`\n\n`);
+  }
   tooltip.appendMarkdown(`**Total:** input ${formatTokenNumber(total.input_tokens)}, cached ${formatTokenNumber(total.cached_input_tokens)}, output ${formatTokenNumber(total.output_tokens)}, reasoning ${formatTokenNumber(total.reasoning_output_tokens)}\n\n`);
   tooltip.appendMarkdown(`**Last:** input ${formatTokenNumber(last.input_tokens)}, cached ${formatTokenNumber(last.cached_input_tokens)}, output ${formatTokenNumber(last.output_tokens)}, reasoning ${formatTokenNumber(last.reasoning_output_tokens)}\n\n`);
 
@@ -174,7 +218,7 @@ export function createMarkdownTooltip(data: RateLimitData): vscode.MarkdownStrin
 
 export function updateStatusBar(data: RateLimitData): void {
   if (!statusBarItem) {
-    log('Status bar item not initialized', true);
+    log('Status bar item not initialized', 'error');
     return;
   }
 
@@ -200,15 +244,18 @@ export function updateStatusBar(data: RateLimitData): void {
     const primaryText = data.primary ? `${Math.round(primaryUsage)}%` : 'N/A';
     const weeklyText = data.secondary ? `${Math.round(weeklyUsage)}%` : 'N/A';
 
-    statusBarItem.text = `⚡ 5H: ${primaryText} | Weekly: ${weeklyText}`;
+    const sourceIndicator = getStatusBarSourceIndicator(data);
+    const sourcePrefix = sourceIndicator ? `${sourceIndicator} | ` : '';
+
+    statusBarItem.text = `⚡ ${sourcePrefix}5H: ${primaryText} | Weekly: ${weeklyText}`;
     statusBarItem.color = getStatusBarColor(maxUsagePercent);
     statusBarItem.tooltip = createMarkdownTooltip(data);
     statusBarItem.show();
 
-    log(`Status bar updated - 5H: ${primaryText}, Weekly: ${weeklyText}`);
+    log(`Status bar updated - 5H: ${primaryText}, Weekly: ${weeklyText}`, 'debug');
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    log(`Error updating status bar: ${errorMessage}`, true);
+    log(`Error updating status bar: ${errorMessage}`, 'error');
 
     statusBarItem.text = '⚡ Codex: Error';
     statusBarItem.color = new vscode.ThemeColor('statusBarItem.errorBackground');
@@ -227,5 +274,5 @@ export function showErrorState(message: string): void {
   statusBarItem.tooltip = new vscode.MarkdownString(`⚠️ ${message}`);
   statusBarItem.show();
 
-  log(`Status bar showing error: ${message}`);
+  log(`Status bar showing error: ${message}`, 'warn');
 }

--- a/src/handlers/webView.ts
+++ b/src/handlers/webView.ts
@@ -52,10 +52,10 @@ export class RateLimitWebView {
     // Handle messages from the webview
     this._panel.webview.onDidReceiveMessage(
       async (message) => {
-        log(`WebView received message: ${JSON.stringify(message)}`, true); // Force log
+        log(`WebView received message: ${JSON.stringify(message)}`, 'debug');
         switch (message.command) {
           case 'refresh':
-            log('WebView refresh triggered', true); // Force log
+            log('WebView refresh triggered', 'info');
             await this._update();
             return;
         }
@@ -96,10 +96,10 @@ export class RateLimitWebView {
       }
 
       this._panel.webview.html = this._getHtml(webview, result.data);
-      log('WebView updated successfully');
+      log('WebView updated successfully', 'debug');
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      log(`Error updating WebView: ${errorMessage}`, true);
+      log(`Error updating WebView: ${errorMessage}`, 'error');
       this._panel.webview.html = this._getErrorHtml(errorMessage);
     }
   }
@@ -109,6 +109,10 @@ export class RateLimitWebView {
     const config = vscode.workspace.getConfiguration('codexRatelimit');
     const warningColor = config.get<string>('color.warningColor', '#f3d898');
     const criticalColor = config.get<string>('color.criticalColor', '#eca7a7');
+    const sourceLabel = this._escapeHtml(data.rate_limit_source?.label || 'Unavailable');
+    const sourceDetail = data.rate_limit_source?.detail
+      ? this._escapeHtml(data.rate_limit_source.detail)
+      : '';
 
     return `<!DOCTYPE html>
     <html lang="en">
@@ -133,6 +137,12 @@ export class RateLimitWebView {
         </div>
 
         ${this._renderProgressSection(data)}
+
+        <div class="token-usage">
+          <h3>Source</h3>
+          <div class="token-line"><strong>Rate-limit source:</strong> ${sourceLabel}</div>
+          ${sourceDetail ? `<div class="token-line"><strong>Source detail:</strong> <code>${sourceDetail}</code></div>` : ''}
+        </div>
 
         <div class="token-usage">
           <h3>📊 Token Usage Summary</h3>
@@ -262,6 +272,15 @@ export class RateLimitWebView {
     } else {
       return 'low';
     }
+  }
+
+  private _escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
   }
 
   private _getErrorHtml(errorMessage: string): string {

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -11,6 +11,19 @@ export interface RateLimit {
   window_minutes: number;
   resets_in_seconds?: number;
   resets_at?: number;
+  reset_after_seconds?: number;
+  reset_at?: number;
+}
+
+export interface RateLimitWindow {
+  primary?: RateLimit;    // 5-hour limit
+  secondary?: RateLimit;  // Weekly limit
+}
+
+export interface RateLimitSource {
+  kind: 'token_count' | 'app_server' | 'session_snapshot';
+  label: string;
+  detail?: string;
 }
 
 export interface TokenCountPayload {
@@ -19,10 +32,7 @@ export interface TokenCountPayload {
     total_token_usage: TokenUsage | null;
     last_token_usage: TokenUsage | null;
   } | null;
-  rate_limits?: {
-    primary?: RateLimit;    // 5-hour limit
-    secondary?: RateLimit;  // Weekly limit
-  };
+  rate_limits?: RateLimitWindow | null;
 }
 
 export interface EventRecord {
@@ -37,6 +47,7 @@ export interface RateLimitData {
   current_time: Date;
   total_usage: TokenUsage;
   last_usage: TokenUsage;
+  rate_limit_source?: RateLimitSource;
   primary?: {
     used_percent: number;
     time_percent: number;

--- a/src/services/codexAppServer.ts
+++ b/src/services/codexAppServer.ts
@@ -99,11 +99,15 @@ function getBundledCodexExecutableCandidates(): string[] {
     case 'win32':
       candidates.push(
         path.join(binRoot, 'windows-x86_64', 'codex.exe'),
+        path.join(binRoot, 'windows-aarch64', 'codex.exe'),
         path.join(binRoot, 'windows-arm64', 'codex.exe')
       );
       break;
     case 'darwin':
       candidates.push(
+        path.join(binRoot, process.arch === 'arm64' ? 'macos-aarch64' : 'macos-x86_64', 'codex'),
+        path.join(binRoot, 'macos-aarch64', 'codex'),
+        path.join(binRoot, 'macos-x86_64', 'codex'),
         path.join(binRoot, process.arch === 'arm64' ? 'darwin-aarch64' : 'darwin-x86_64', 'codex'),
         path.join(binRoot, 'darwin-aarch64', 'codex'),
         path.join(binRoot, 'darwin-x86_64', 'codex')

--- a/src/services/codexAppServer.ts
+++ b/src/services/codexAppServer.ts
@@ -1,0 +1,358 @@
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { RateLimit, RateLimitWindow } from '../interfaces/types';
+import { log } from './logger';
+
+const APP_SERVER_CACHE_TTL_MS = 15 * 1000;
+const APP_SERVER_REQUEST_TIMEOUT_MS = 5 * 1000;
+const CHATGPT_EXTENSION_ID = 'openai.chatgpt';
+
+type AppServerRateLimitWindow = {
+  resetsAt?: number | null;
+  usedPercent: number;
+  windowDurationMins?: number | null;
+};
+
+type AppServerRateLimitSnapshot = {
+  limitId?: string | null;
+  limitName?: string | null;
+  planType?: string | null;
+  primary?: AppServerRateLimitWindow | null;
+  secondary?: AppServerRateLimitWindow | null;
+};
+
+type AppServerRateLimitsResponse = {
+  rateLimits?: AppServerRateLimitSnapshot | null;
+  rateLimitsByLimitId?: Record<string, AppServerRateLimitSnapshot | undefined> | null;
+};
+
+type AppServerRequestResult = {
+  rateLimits: RateLimitWindow;
+  source: string;
+};
+
+let cachedRateLimits:
+  | {
+      expiresAt: number;
+      result: AppServerRequestResult | null;
+    }
+  | undefined;
+
+let inflightRequest: Promise<AppServerRequestResult | null> | undefined;
+
+function toExtensionRateLimit(rateLimit: AppServerRateLimitWindow | null | undefined): RateLimit | undefined {
+  if (!rateLimit) {
+    return undefined;
+  }
+
+  return {
+    used_percent: rateLimit.usedPercent,
+    window_minutes: typeof rateLimit.windowDurationMins === 'number' ? rateLimit.windowDurationMins : 0,
+    reset_at: typeof rateLimit.resetsAt === 'number' ? rateLimit.resetsAt : undefined
+  };
+}
+
+function selectSnapshot(response: AppServerRateLimitsResponse): AppServerRateLimitSnapshot | null {
+  if (response.rateLimitsByLimitId?.codex) {
+    return response.rateLimitsByLimitId.codex;
+  }
+
+  if (response.rateLimitsByLimitId) {
+    for (const snapshot of Object.values(response.rateLimitsByLimitId)) {
+      if (snapshot) {
+        return snapshot;
+      }
+    }
+  }
+
+  return response.rateLimits ?? null;
+}
+
+function normalizeRateLimits(response: AppServerRateLimitsResponse): RateLimitWindow | null {
+  const snapshot = selectSnapshot(response);
+  if (!snapshot) {
+    return null;
+  }
+
+  const primary = toExtensionRateLimit(snapshot.primary);
+  const secondary = toExtensionRateLimit(snapshot.secondary);
+
+  if (!primary && !secondary) {
+    return null;
+  }
+
+  return { primary, secondary };
+}
+
+function getBundledCodexExecutableCandidates(): string[] {
+  const extension = vscode.extensions.getExtension(CHATGPT_EXTENSION_ID);
+  if (!extension) {
+    return [];
+  }
+
+  const binRoot = path.join(extension.extensionPath, 'bin');
+  const candidates: string[] = [];
+
+  switch (process.platform) {
+    case 'win32':
+      candidates.push(
+        path.join(binRoot, 'windows-x86_64', 'codex.exe'),
+        path.join(binRoot, 'windows-arm64', 'codex.exe')
+      );
+      break;
+    case 'darwin':
+      candidates.push(
+        path.join(binRoot, process.arch === 'arm64' ? 'darwin-aarch64' : 'darwin-x86_64', 'codex'),
+        path.join(binRoot, 'darwin-aarch64', 'codex'),
+        path.join(binRoot, 'darwin-x86_64', 'codex')
+      );
+      break;
+    case 'linux':
+      candidates.push(
+        path.join(binRoot, process.arch === 'arm64' ? 'linux-aarch64' : 'linux-x86_64', 'codex'),
+        path.join(binRoot, 'linux-aarch64', 'codex'),
+        path.join(binRoot, 'linux-x86_64', 'codex')
+      );
+      break;
+    default:
+      break;
+  }
+
+  return candidates.filter(candidate => fs.existsSync(candidate));
+}
+
+function getCodexExecutableCandidates(): string[] {
+  const bundledCandidates = getBundledCodexExecutableCandidates();
+  const candidates = [...bundledCandidates, 'codex'];
+  return Array.from(new Set(candidates));
+}
+
+function parseResponseLine(line: string): unknown {
+  return JSON.parse(line) as unknown;
+}
+
+function requestRateLimitsFromExecutable(executable: string): Promise<AppServerRequestResult | null> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      executable,
+      ['app-server', '--listen', 'stdio://', '--analytics-default-enabled'],
+      {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true
+      }
+    );
+
+    let stdoutBuffer = '';
+    let stderrBuffer = '';
+    let settled = false;
+    let initialized = false;
+
+    const timeout = setTimeout(() => {
+      finish(new Error(`Timed out waiting for Codex app-server response from ${executable}`));
+    }, APP_SERVER_REQUEST_TIMEOUT_MS);
+
+    function cleanup(): void {
+      clearTimeout(timeout);
+      child.stdout.removeListener('data', handleStdout);
+      child.stderr.removeListener('data', handleStderr);
+      child.removeListener('error', handleError);
+      child.removeListener('close', handleClose);
+    }
+
+    function finish(error?: Error, result?: AppServerRequestResult | null): void {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+
+      try {
+        child.stdin.end();
+      } catch {
+        // Ignore teardown errors.
+      }
+
+      if (!child.killed) {
+        try {
+          child.kill();
+        } catch {
+          // Ignore teardown errors.
+        }
+      }
+
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve(result ?? null);
+    }
+
+    function writeMessage(message: unknown): void {
+      child.stdin.write(`${JSON.stringify(message)}\n`);
+    }
+
+    function handleMessage(message: unknown): void {
+      if (!message || typeof message !== 'object') {
+        return;
+      }
+
+      const jsonMessage = message as {
+        id?: number | string;
+        result?: unknown;
+        error?: { message?: string };
+      };
+
+      if (jsonMessage.id === 1) {
+        if (jsonMessage.error) {
+          finish(new Error(jsonMessage.error.message || `Failed to initialize Codex app-server via ${executable}`));
+          return;
+        }
+
+        if (!initialized) {
+          initialized = true;
+          writeMessage({
+            id: 2,
+            method: 'account/rateLimits/read',
+            params: null
+          });
+        }
+
+        return;
+      }
+
+      if (jsonMessage.id !== 2) {
+        return;
+      }
+
+      if (jsonMessage.error) {
+        finish(new Error(jsonMessage.error.message || `Failed to read Codex rate limits via ${executable}`));
+        return;
+      }
+
+      const normalized = normalizeRateLimits((jsonMessage.result ?? null) as AppServerRateLimitsResponse);
+      if (!normalized) {
+        finish(undefined, null);
+        return;
+      }
+
+      finish(undefined, {
+        rateLimits: normalized,
+        source: executable
+      });
+    }
+
+    function processStdoutBuffer(): void {
+      let newlineIndex = stdoutBuffer.indexOf('\n');
+
+      while (newlineIndex >= 0) {
+        const line = stdoutBuffer.slice(0, newlineIndex).trim();
+        stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+
+        if (line.length > 0) {
+          try {
+            handleMessage(parseResponseLine(line));
+          } catch (error) {
+            log(`Failed to parse Codex app-server output from ${executable}: ${error}`, 'warn');
+          }
+        }
+
+        newlineIndex = stdoutBuffer.indexOf('\n');
+      }
+    }
+
+    function handleStdout(chunk: Buffer | string): void {
+      stdoutBuffer += chunk.toString();
+      processStdoutBuffer();
+    }
+
+    function handleStderr(chunk: Buffer | string): void {
+      stderrBuffer += chunk.toString();
+    }
+
+    function handleError(error: Error): void {
+      finish(new Error(`Failed to start Codex app-server via ${executable}: ${error.message}`));
+    }
+
+    function handleClose(code: number | null): void {
+      if (settled) {
+        return;
+      }
+
+      const stderrMessage = stderrBuffer.trim();
+      const closeMessage = stderrMessage || `Codex app-server exited before returning a response (code: ${code ?? 'unknown'})`;
+      finish(new Error(closeMessage));
+    }
+
+    child.stdout.on('data', handleStdout);
+    child.stderr.on('data', handleStderr);
+    child.on('error', handleError);
+    child.on('close', handleClose);
+
+    writeMessage({
+      id: 1,
+      method: 'initialize',
+      params: {
+        clientInfo: {
+          name: 'codex-ratelimit',
+          version: '0.13.0'
+        }
+      }
+    });
+  });
+}
+
+async function fetchRateLimitsFromAppServer(): Promise<AppServerRequestResult | null> {
+  const executables = getCodexExecutableCandidates();
+  const failures: string[] = [];
+
+  for (const executable of executables) {
+    try {
+      const result = await requestRateLimitsFromExecutable(executable);
+      if (result) {
+        return result;
+      }
+
+      failures.push(`${executable}: no usable rate limits returned`);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      failures.push(`${executable}: ${errorMessage}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    log(`Codex app-server fallback failed for all candidates: ${failures.join(' | ')}`, 'warn');
+  }
+
+  return null;
+}
+
+export async function getCodexRateLimitsFromAppServer(): Promise<AppServerRequestResult | null> {
+  const now = Date.now();
+
+  if (cachedRateLimits && cachedRateLimits.expiresAt > now) {
+    return cachedRateLimits.result;
+  }
+
+  if (inflightRequest) {
+    return inflightRequest;
+  }
+
+  inflightRequest = fetchRateLimitsFromAppServer()
+    .then(result => {
+      cachedRateLimits = {
+        expiresAt: Date.now() + APP_SERVER_CACHE_TTL_MS,
+        result
+      };
+
+      return result;
+    })
+    .finally(() => {
+      inflightRequest = undefined;
+    });
+
+  return inflightRequest;
+}

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -2,36 +2,78 @@ import * as vscode from 'vscode';
 
 let outputChannel: vscode.OutputChannel | undefined;
 
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'off';
+
+type ActiveLogLevel = Exclude<LogLevel, 'off'>;
+
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  off: 50
+};
+
 export function initializeLogging(): void {
   if (!outputChannel) {
     outputChannel = vscode.window.createOutputChannel('Codex Rate Limit');
   }
 }
 
-export function log(message: string, isError: boolean = false): void {
+function getConfiguredLogLevel(config: vscode.WorkspaceConfiguration): LogLevel {
+  const inspected = config.inspect<LogLevel>('logLevel');
+  const hasExplicitLogLevel =
+    inspected?.globalValue !== undefined ||
+    inspected?.workspaceValue !== undefined ||
+    inspected?.workspaceFolderValue !== undefined;
+
+  if (hasExplicitLogLevel) {
+    return config.get<LogLevel>('logLevel', 'warn');
+  }
+
+  return config.get<boolean>('enableLogging', false) ? 'info' : 'warn';
+}
+
+function shouldLog(config: vscode.WorkspaceConfiguration, level: ActiveLogLevel): boolean {
+  const configuredLevel = getConfiguredLogLevel(config);
+  if (configuredLevel === 'off') {
+    return false;
+  }
+
+  return LOG_LEVEL_PRIORITY[level] >= LOG_LEVEL_PRIORITY[configuredLevel];
+}
+
+function formatLevel(level: ActiveLogLevel): string {
+  return level.toUpperCase().padEnd(5, ' ');
+}
+
+export function log(message: string, level: ActiveLogLevel = 'info'): void {
   const config = vscode.workspace.getConfiguration('codexRatelimit');
-  const enableLogging = config.get<boolean>('enableLogging', false);
   const showOutputOnError = config.get<boolean>('showOutputOnError', false);
 
-  // Always log errors and important messages, only filter debug messages
-  if (!enableLogging && !isError && !message.includes('Manual refresh') && !message.includes('Extension activation')) {
+  if (!shouldLog(config, level)) {
     return;
   }
 
   const timestamp = new Date().toISOString();
-  const logMessage = `[${timestamp}] ${message}`;
+  const logMessage = `[${timestamp}] [${formatLevel(level)}] ${message}`;
 
   if (outputChannel) {
     outputChannel.appendLine(logMessage);
-    if (isError && showOutputOnError) {
+    if (level === 'error' && showOutputOnError) {
       outputChannel.show(true);
     }
   }
 
-  if (isError) {
-    console.error(logMessage);
-  } else {
-    console.log(logMessage);
+  switch (level) {
+    case 'error':
+      console.error(logMessage);
+      break;
+    case 'warn':
+      console.warn(logMessage);
+      break;
+    default:
+      console.log(logMessage);
   }
 }
 

--- a/src/services/ratelimitParser.ts
+++ b/src/services/ratelimitParser.ts
@@ -1,31 +1,49 @@
 import * as fs from 'fs';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
 import { glob } from 'glob';
-import { EventRecord, RateLimit, RateLimitData, ParseResult, TokenCountPayload, TokenUsage } from '../interfaces/types';
-import { log } from './logger';
 import * as vscode from 'vscode';
+import { EventRecord, ParseResult, RateLimit, RateLimitData, RateLimitSource, RateLimitWindow, TokenUsage } from '../interfaces/types';
+import { getCodexRateLimitsFromAppServer } from './codexAppServer';
+import { log } from './logger';
+
+type RateLimitSection = NonNullable<RateLimitData['primary']>;
+
+type SessionRecordMatch = {
+  file: string;
+  record: EventRecord;
+};
+
+type SessionFileParseResult = {
+  latestRecord: EventRecord | null;
+  latestRateLimitRecord: EventRecord | null;
+};
 
 function getSessionBasePath(customPath?: string): string {
   if (customPath) {
     return path.resolve(customPath.replace('~', os.homedir()));
   }
+
   return path.join(os.homedir(), '.codex', 'sessions');
 }
 
-function calculateResetTime(recordTimestamp: Date, rateLimit: RateLimit): { resetTime: Date; isOutdated: boolean; secondsUntilReset: number } {
+function calculateResetTime(referenceTime: Date, rateLimit: RateLimit): { resetTime: Date; isOutdated: boolean; secondsUntilReset: number } {
   const currentTime = new Date();
   let resetTime: Date | null = null;
 
-  if (typeof rateLimit.resets_at === 'number' && !Number.isNaN(rateLimit.resets_at)) {
+  if (typeof rateLimit.reset_at === 'number' && !Number.isNaN(rateLimit.reset_at)) {
+    resetTime = new Date(rateLimit.reset_at * 1000);
+  } else if (typeof rateLimit.resets_at === 'number' && !Number.isNaN(rateLimit.resets_at)) {
     resetTime = new Date(rateLimit.resets_at * 1000);
+  } else if (typeof rateLimit.reset_after_seconds === 'number' && !Number.isNaN(rateLimit.reset_after_seconds)) {
+    resetTime = new Date(referenceTime.getTime() + rateLimit.reset_after_seconds * 1000);
   } else if (typeof rateLimit.resets_in_seconds === 'number' && !Number.isNaN(rateLimit.resets_in_seconds)) {
-    resetTime = new Date(recordTimestamp.getTime() + rateLimit.resets_in_seconds * 1000);
+    resetTime = new Date(referenceTime.getTime() + rateLimit.resets_in_seconds * 1000);
   }
 
   if (!resetTime || Number.isNaN(resetTime.getTime())) {
     return {
-      resetTime: recordTimestamp,
+      resetTime: referenceTime,
       isOutdated: true,
       secondsUntilReset: 0
     };
@@ -37,39 +55,58 @@ function calculateResetTime(recordTimestamp: Date, rateLimit: RateLimit): { rese
   return { resetTime, isOutdated, secondsUntilReset };
 }
 
-async function parseSessionFile(filePath: string): Promise<EventRecord | null> {
+function parseRecordTimestamp(timestamp: string): Date | null {
+  const parsed = new Date(timestamp.replace('Z', '+00:00'));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+async function parseSessionFile(filePath: string): Promise<SessionFileParseResult> {
   try {
     const content = await fs.promises.readFile(filePath, 'utf-8');
     const lines = content.split('\n').filter(line => line.trim());
 
     let latestRecord: EventRecord | null = null;
-    let latestTimestamp: Date | null = null;
+    let latestRecordTimestamp: Date | null = null;
+    let latestRateLimitRecord: EventRecord | null = null;
+    let latestRateLimitTimestamp: Date | null = null;
 
     for (const line of lines) {
       try {
-        const record = JSON.parse(line);
+        const record = JSON.parse(line) as EventRecord;
 
-        // Check if this is a token_count event
-        if (record.type === 'event_msg' &&
-            record.payload?.type === 'token_count') {
-
-          const timestamp = new Date(record.timestamp.replace('Z', '+00:00'));
-
-          if (!latestTimestamp || timestamp > latestTimestamp) {
-            latestTimestamp = timestamp;
-            latestRecord = record as EventRecord;
-          }
+        if (record.type !== 'event_msg' || record.payload?.type !== 'token_count') {
+          continue;
         }
-      } catch (jsonError) {
-        // Skip malformed lines
+
+        const timestamp = parseRecordTimestamp(record.timestamp);
+        if (!timestamp) {
+          continue;
+        }
+
+        if (!latestRecordTimestamp || timestamp > latestRecordTimestamp) {
+          latestRecordTimestamp = timestamp;
+          latestRecord = record;
+        }
+
+        if (record.payload.rate_limits && (!latestRateLimitTimestamp || timestamp > latestRateLimitTimestamp)) {
+          latestRateLimitTimestamp = timestamp;
+          latestRateLimitRecord = record;
+        }
+      } catch {
         continue;
       }
     }
 
-    return latestRecord;
+    return {
+      latestRecord,
+      latestRateLimitRecord
+    };
   } catch (error) {
-    log(`Error reading session file ${filePath}: ${error}`, true);
-    return null;
+    log(`Error reading session file ${filePath}: ${error}`, 'warn');
+    return {
+      latestRecord: null,
+      latestRateLimitRecord: null
+    };
   }
 }
 
@@ -84,7 +121,6 @@ async function getSessionFilesWithMtime(sessionPath: string): Promise<{ file: st
     const year = searchDate.getFullYear();
     const month = String(searchDate.getMonth() + 1).padStart(2, '0');
     const day = String(searchDate.getDate()).padStart(2, '0');
-
     const datePath = path.join(sessionPath, String(year), month, day);
 
     if (!fs.existsSync(datePath)) {
@@ -100,11 +136,11 @@ async function getSessionFilesWithMtime(sessionPath: string): Promise<{ file: st
           const stats = await fs.promises.stat(file);
           sessionFiles.push({ file, mtimeMs: stats.mtimeMs });
         } catch (error) {
-          log(`Error getting mtime for session file ${file}: ${error}`, false);
+          log(`Error getting mtime for session file ${file}: ${error}`, 'warn');
         }
       }
     } catch (error) {
-      log(`Error collecting session files from ${datePath}: ${error}`, false);
+      log(`Error collecting session files from ${datePath}: ${error}`, 'warn');
     }
   }
 
@@ -112,17 +148,11 @@ async function getSessionFilesWithMtime(sessionPath: string): Promise<{ file: st
   return sessionFiles;
 }
 
-async function findLatestTokenCountRecord(basePath?: string): Promise<{ file: string; record: EventRecord } | null> {
-  const sessionPath = getSessionBasePath(basePath);
-
-  if (!fs.existsSync(sessionPath)) {
-    log(`Session path does not exist: ${sessionPath}`, true);
-    return null;
-  }
-
+async function getOrderedSessionFiles(sessionPath: string): Promise<string[]> {
   const nowMs = Date.now();
   const oneHourAgoMs = nowMs - 60 * 60 * 1000;
-  const attemptedFiles = new Set<string>();
+  const orderedFiles: string[] = [];
+  const seenFiles = new Set<string>();
 
   const today = new Date();
   const todayYear = today.getFullYear();
@@ -134,7 +164,6 @@ async function findLatestTokenCountRecord(basePath?: string): Promise<{ file: st
     try {
       const pattern = path.join(todayPath, 'rollout-*.jsonl').replace(/\\/g, '/');
       const files = await glob(pattern, { nodir: true });
-
       const recentFiles: { file: string; mtimeMs: number }[] = [];
 
       for (const file of files) {
@@ -144,150 +173,72 @@ async function findLatestTokenCountRecord(basePath?: string): Promise<{ file: st
             recentFiles.push({ file, mtimeMs: stats.mtimeMs });
           }
         } catch (error) {
-          log(`Error reading stats for session file ${file}: ${error}`, false);
+          log(`Error reading stats for session file ${file}: ${error}`, 'warn');
         }
       }
 
       recentFiles.sort((a, b) => b.mtimeMs - a.mtimeMs);
 
       for (const { file } of recentFiles) {
-        attemptedFiles.add(file);
-        const record = await parseSessionFile(file);
-        if (record) {
-          return { file, record };
-        }
+        seenFiles.add(file);
+        orderedFiles.push(file);
       }
     } catch (error) {
-      log(`Error searching today's session files in ${todayPath}: ${error}`, false);
+      log(`Error searching today's session files in ${todayPath}: ${error}`, 'warn');
     }
   }
 
   const sessionFiles = await getSessionFilesWithMtime(sessionPath);
-
   for (const { file } of sessionFiles) {
-    if (attemptedFiles.has(file)) {
+    if (seenFiles.has(file)) {
       continue;
     }
 
-    const record = await parseSessionFile(file);
-    if (record) {
-      return { file, record };
-    }
+    seenFiles.add(file);
+    orderedFiles.push(file);
   }
 
-  return null;
+  return orderedFiles;
 }
 
-export async function getRateLimitData(customPath?: string): Promise<ParseResult> {
-  try {
-    const config = vscode.workspace.getConfiguration('codexRatelimit');
-    const sessionPath = customPath || config.get<string>('sessionPath', '');
+async function findLatestSessionRecords(basePath?: string): Promise<{
+  latestTokenCount: SessionRecordMatch | null;
+  latestRateLimitRecord: SessionRecordMatch | null;
+}> {
+  const sessionPath = getSessionBasePath(basePath);
 
-    log(`Searching for latest token_count event in ${sessionPath || 'default path'}...`);
-
-    const result = await findLatestTokenCountRecord(sessionPath || undefined);
-    if (!result) {
-      return {
-        found: false,
-        error: 'No token_count events found in session files'
-      };
-    }
-
-    const { file, record } = result;
-    const payload = record.payload;
-    const rateLimits = payload.rate_limits || {};
-    const info = payload.info;
-
-    const recordTimestamp = new Date(record.timestamp.replace('Z', '+00:00'));
-    const currentTime = new Date();
-
-    if (!info) {
-      log('Token count payload missing usage info; defaulting to zero values.', false);
-    } else if (!info.total_token_usage || !info.last_token_usage) {
-      log('Token count payload has incomplete usage info; defaulting missing fields to zero.', false);
-    }
-
-    const totalUsage = info?.total_token_usage ?? createEmptyTokenUsage();
-    const lastUsage = info?.last_token_usage ?? createEmptyTokenUsage();
-
-    const data: RateLimitData = {
-      file_path: file,
-      record_timestamp: recordTimestamp,
-      current_time: currentTime,
-      total_usage: totalUsage,
-      last_usage: lastUsage
-    };
-
-    // Process primary (5h) rate limits
-    if (rateLimits.primary) {
-      const primary = rateLimits.primary;
-      const { resetTime, isOutdated, secondsUntilReset } = calculateResetTime(recordTimestamp, primary);
-      const rawWindowMinutes = primary.window_minutes;
-      const windowMinutes = typeof rawWindowMinutes === 'number' && rawWindowMinutes > 0 ? rawWindowMinutes : 0;
-      const windowSeconds = windowMinutes * 60;
-
-      let timePercent: number;
-      if (windowSeconds <= 0) {
-        timePercent = 0;
-      } else if (isOutdated) {
-        timePercent = 100.0;
-      } else {
-        const elapsedSeconds = windowSeconds - secondsUntilReset;
-        const boundedElapsedSeconds = Math.max(0, Math.min(windowSeconds, elapsedSeconds));
-        timePercent = (boundedElapsedSeconds / windowSeconds) * 100;
-      }
-
-      data.primary = {
-        used_percent: primary.used_percent,
-        time_percent: Math.max(0, Math.min(100, timePercent)),
-        reset_time: resetTime,
-        outdated: isOutdated,
-        window_minutes: windowMinutes
-      };
-    }
-
-    // Process secondary (weekly) rate limits
-    if (rateLimits.secondary) {
-      const secondary = rateLimits.secondary;
-      const { resetTime, isOutdated, secondsUntilReset } = calculateResetTime(recordTimestamp, secondary);
-      const rawWindowMinutes = secondary.window_minutes;
-      const windowMinutes = typeof rawWindowMinutes === 'number' && rawWindowMinutes > 0 ? rawWindowMinutes : 0;
-      const windowSeconds = windowMinutes * 60;
-
-      let timePercent: number;
-      if (windowSeconds <= 0) {
-        timePercent = 0;
-      } else if (isOutdated) {
-        timePercent = 100.0;
-      } else {
-        const elapsedSeconds = windowSeconds - secondsUntilReset;
-        const boundedElapsedSeconds = Math.max(0, Math.min(windowSeconds, elapsedSeconds));
-        timePercent = (boundedElapsedSeconds / windowSeconds) * 100;
-      }
-
-      data.secondary = {
-        used_percent: secondary.used_percent,
-        time_percent: Math.max(0, Math.min(100, timePercent)),
-        reset_time: resetTime,
-        outdated: isOutdated,
-        window_minutes: windowMinutes
-      };
-    }
-
-    log(`Found latest token_count event in: ${file}`);
+  if (!fs.existsSync(sessionPath)) {
+    log(`Session path does not exist: ${sessionPath}`, 'warn');
     return {
-      found: true,
-      data
-    };
-
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    log(`Error getting rate limit data: ${errorMessage}`, true);
-    return {
-      found: false,
-      error: errorMessage
+      latestTokenCount: null,
+      latestRateLimitRecord: null
     };
   }
+
+  const orderedFiles = await getOrderedSessionFiles(sessionPath);
+  let latestTokenCount: SessionRecordMatch | null = null;
+  let latestRateLimitRecord: SessionRecordMatch | null = null;
+
+  for (const file of orderedFiles) {
+    if (latestTokenCount && latestRateLimitRecord) {
+      break;
+    }
+
+    const parsed = await parseSessionFile(file);
+
+    if (!latestTokenCount && parsed.latestRecord) {
+      latestTokenCount = { file, record: parsed.latestRecord };
+    }
+
+    if (!latestRateLimitRecord && parsed.latestRateLimitRecord) {
+      latestRateLimitRecord = { file, record: parsed.latestRateLimitRecord };
+    }
+  }
+
+  return {
+    latestTokenCount,
+    latestRateLimitRecord
+  };
 }
 
 function createEmptyTokenUsage(): TokenUsage {
@@ -300,9 +251,170 @@ function createEmptyTokenUsage(): TokenUsage {
   };
 }
 
+function createEmptyRateLimitData(sourceFile: string, currentTime: Date): RateLimitData {
+  return {
+    file_path: sourceFile,
+    record_timestamp: currentTime,
+    current_time: currentTime,
+    total_usage: createEmptyTokenUsage(),
+    last_usage: createEmptyTokenUsage()
+  };
+}
+
+function setRateLimitSource(data: RateLimitData, source: RateLimitSource): void {
+  data.rate_limit_source = source;
+}
+
+function buildRateLimitSection(referenceTime: Date, rateLimit: RateLimit): RateLimitSection {
+  const { resetTime, isOutdated, secondsUntilReset } = calculateResetTime(referenceTime, rateLimit);
+  const rawWindowMinutes = rateLimit.window_minutes;
+  const windowMinutes = typeof rawWindowMinutes === 'number' && rawWindowMinutes > 0 ? rawWindowMinutes : 0;
+  const windowSeconds = windowMinutes * 60;
+
+  let timePercent: number;
+  if (windowSeconds <= 0) {
+    timePercent = 0;
+  } else if (isOutdated) {
+    timePercent = 100.0;
+  } else {
+    const elapsedSeconds = windowSeconds - secondsUntilReset;
+    const boundedElapsedSeconds = Math.max(0, Math.min(windowSeconds, elapsedSeconds));
+    timePercent = (boundedElapsedSeconds / windowSeconds) * 100;
+  }
+
+  return {
+    used_percent: rateLimit.used_percent,
+    time_percent: Math.max(0, Math.min(100, timePercent)),
+    reset_time: resetTime,
+    outdated: isOutdated,
+    window_minutes: windowMinutes
+  };
+}
+
+function applyRateLimits(data: RateLimitData, rateLimits: RateLimitWindow | null | undefined, referenceTime: Date): boolean {
+  let applied = false;
+
+  if (rateLimits?.primary) {
+    data.primary = buildRateLimitSection(referenceTime, rateLimits.primary);
+    applied = true;
+  }
+
+  if (rateLimits?.secondary) {
+    data.secondary = buildRateLimitSection(referenceTime, rateLimits.secondary);
+    applied = true;
+  }
+
+  return applied;
+}
+
 function formatTokenNumber(num: number): string {
   const numInK = Math.round(num / 1000);
   return numInK.toLocaleString('en-US') + ' K';
+}
+
+export async function getRateLimitData(customPath?: string): Promise<ParseResult> {
+  try {
+    const config = vscode.workspace.getConfiguration('codexRatelimit');
+    const configuredSessionPath = customPath ?? config.get<string>('sessionPath', '');
+    const sessionPath = configuredSessionPath.trim();
+    const shouldUseAppServerFallback = !customPath && sessionPath.length === 0;
+
+    log(`Searching for latest token_count event in ${sessionPath || 'default path'}...`, 'debug');
+
+    const currentTime = new Date();
+    const sessionRecords = await findLatestSessionRecords(sessionPath || undefined);
+    const sessionResult = sessionRecords.latestTokenCount;
+    const latestRateLimitRecord = sessionRecords.latestRateLimitRecord;
+
+    let data = createEmptyRateLimitData(
+      sessionResult?.file || latestRateLimitRecord?.file || 'Codex sessions',
+      currentTime
+    );
+
+    if (sessionResult) {
+      const { file, record } = sessionResult;
+      const payload = record.payload;
+      const info = payload.info;
+
+      if (!info) {
+        log('Token count payload missing usage info; defaulting to zero values.', 'warn');
+      } else if (!info.total_token_usage || !info.last_token_usage) {
+        log('Token count payload has incomplete usage info; defaulting missing fields to zero.', 'warn');
+      }
+
+      data = {
+        file_path: file,
+        record_timestamp: parseRecordTimestamp(record.timestamp) || currentTime,
+        current_time: currentTime,
+        total_usage: info?.total_token_usage ?? createEmptyTokenUsage(),
+        last_usage: info?.last_token_usage ?? createEmptyTokenUsage()
+      };
+
+      log(`Found latest token_count event in: ${file}`, 'debug');
+    }
+
+    let appliedRateLimits = false;
+
+    if (sessionResult) {
+      appliedRateLimits = applyRateLimits(data, sessionResult.record.payload.rate_limits, data.record_timestamp);
+      if (appliedRateLimits) {
+        setRateLimitSource(data, {
+          kind: 'token_count',
+          label: 'Live session token_count',
+          detail: sessionResult.file
+        });
+        log(`Using live session rate limits from: ${sessionResult.file}`, 'info');
+      }
+    }
+
+    if (!appliedRateLimits && shouldUseAppServerFallback) {
+      const appServerResult = await getCodexRateLimitsFromAppServer();
+
+      if (appServerResult) {
+        appliedRateLimits = applyRateLimits(data, appServerResult.rateLimits, currentTime);
+        if (appliedRateLimits) {
+          setRateLimitSource(data, {
+            kind: 'app_server',
+            label: 'Codex app-server fallback',
+            detail: appServerResult.source
+          });
+          log(`Using Codex app-server fallback rate limits from: ${appServerResult.source}`, 'info');
+        }
+      }
+    }
+
+    if (!appliedRateLimits && latestRateLimitRecord?.record.payload.rate_limits) {
+      const referenceTime = parseRecordTimestamp(latestRateLimitRecord.record.timestamp) || currentTime;
+      appliedRateLimits = applyRateLimits(data, latestRateLimitRecord.record.payload.rate_limits, referenceTime);
+      if (appliedRateLimits) {
+        setRateLimitSource(data, {
+          kind: 'session_snapshot',
+          label: 'Session snapshot fallback',
+          detail: latestRateLimitRecord.file
+        });
+        log(`Using most recent session rate limits from: ${latestRateLimitRecord.file}`, 'info');
+      }
+    }
+
+    if (!sessionResult && !appliedRateLimits) {
+      return {
+        found: false,
+        error: 'No token_count events or rate-limit snapshots found in recent Codex sessions'
+      };
+    }
+
+    return {
+      found: true,
+      data
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    log(`Error getting rate limit data: ${errorMessage}`, 'error');
+    return {
+      found: false,
+      error: errorMessage
+    };
+  }
 }
 
 export function formatTokenUsage(usage: { input_tokens: number; cached_input_tokens: number; output_tokens: number; reasoning_output_tokens: number; total_tokens: number }): string {

--- a/src/utils/updateStats.ts
+++ b/src/utils/updateStats.ts
@@ -14,7 +14,7 @@ let isWindowFocused = true;
 
 export function setWindowFocused(focused: boolean): void {
   isWindowFocused = focused;
-  log(`Window focus changed: ${focused ? 'focused' : 'unfocused'}`);
+  log(`Window focus changed: ${focused ? 'focused' : 'unfocused'}`, 'debug');
 
   if (focused) {
     // Resume updates when window gains focus
@@ -30,12 +30,12 @@ export function startRefreshTimer(): void {
   stopRefreshTimer();
 
   if (!isWindowFocused) {
-    log('Skipping refresh timer start - window not focused');
+    log('Skipping refresh timer start - window not focused', 'debug');
     return;
   }
 
   const intervalMs = getRefreshIntervalMs();
-  log(`Starting refresh timer with ${intervalMs / 1000}-second interval`);
+  log(`Starting refresh timer with ${intervalMs / 1000}-second interval`, 'debug');
 
   // Do initial update immediately
   updateStats();
@@ -52,42 +52,42 @@ export function stopRefreshTimer(): void {
   if (refreshTimer) {
     clearInterval(refreshTimer);
     refreshTimer = undefined;
-    log('Refresh timer stopped');
+    log('Refresh timer stopped', 'debug');
   }
 }
 
 export async function updateStats(): Promise<void> {
   try {
-    log('Starting stats update...');
+    log('Starting stats update...', 'debug');
 
     const result = await getRateLimitData();
 
     if (!result.found) {
       const errorMessage = result.error || 'Unknown error occurred';
-      log(`No rate limit data found: ${errorMessage}`, true);
+      log(`No rate limit data found: ${errorMessage}`, 'warn');
       showErrorState(errorMessage);
       return;
     }
 
     if (!result.data) {
-      log('Rate limit data is undefined', true);
+      log('Rate limit data is undefined', 'error');
       showErrorState('Rate limit data is undefined');
       return;
     }
 
     // Update the status bar with the new data
     updateStatusBar(result.data);
-    log('Stats update completed successfully');
+    log('Stats update completed successfully', 'debug');
 
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    log(`Error during stats update: ${errorMessage}`, true);
+    log(`Error during stats update: ${errorMessage}`, 'error');
     showErrorState(`Update failed: ${errorMessage}`);
   }
 }
 
 // Clean up function for extension deactivation
 export function cleanup(): void {
-  log('Cleaning up stats update timer');
+  log('Cleaning up stats update timer', 'debug');
   stopRefreshTimer();
 }


### PR DESCRIPTION
## Summary
- add a local `codex app-server` fallback for rate limits when newer `token_count` events omit `rate_limits`
- fall back to the most recent session snapshot with `rate_limits` if the app-server path is unavailable
- show the active rate-limit source in the tooltip, details view, and optionally in the status bar
- add explicit log levels (`debug`, `info`, `warn`, `error`) plus clearer source-switch logging
- prefer bundled Codex executables before `codex` on `PATH` and avoid noisy per-candidate failure logs when a later candidate succeeds
- add a packaging helper that writes `codex-ratelimit-<version>.vsix`
- update the README and changelog to document the new behavior

## Display
### Status Bar
<img width="336" height="42" alt="grafik" src="https://github.com/user-attachments/assets/fe536c15-0289-4368-84c1-e6261bdb7f62" />

### Mouse-over in Status Bar
<img width="513" height="582" alt="grafik" src="https://github.com/user-attachments/assets/d1200112-ad6e-4053-ae48-d80922a805a9" />

### Details view
<img width="1249" height="1168" alt="grafik" src="https://github.com/user-attachments/assets/fdc3d213-8a6f-4835-ac75-41180400c22f" />




## Testing
- `npm run compile`
- `npm run package:vsix`
- manual validation in VS Code against local Codex session data, including app-server fallback and source display

## Note
All code, documentation, and packaging changes in this PR were created with AI assistance.